### PR TITLE
README: Add `fetch-depth` parameter to the `checkout` action

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2-beta
+      with:
+        fetch-depth: 0
     - uses: simplabs/ember-asset-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
+
+Note: as this action requires access to the "base" commit of a PR branch we need to fetch the whole repo by adding `fetch-depth: 0` to the `actions/checkout` configuration.
+
+If you would like to follow discussion on this problem you can find the issue on github here: https://github.com/actions/checkout/issues/93


### PR DESCRIPTION
Suggesting that a user depend on `actions/checkout@master` is a bit of a dangerous thing because that action recently changed its default behaviour.

This updates our recommended config to: 

- target a specific branch of the upstream `actions/checkout` action
- use the new required config to make this work