### PR TITLE
Use `yarn --frozen-lockfile`

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -66,7 +66,7 @@ export async function getPullRequest(context, octokit) {
 
 export async function getAssetSizes() {
   if (fs.existsSync('yarn.lock')) {
-    await exec('yarn');
+    await exec('yarn --frozen-lockfile');
   } else {
     await exec('npm ci');
   }


### PR DESCRIPTION
The default `yarn` command will potentially update the `yarn.lock` file, when being run. This is generally not great on CI, but especially problematic here, as it will prevent the second `git checkout` from working, as it complains that there are modified files that would be overwritten on checkout.

This PR changes this to run `yarn --frozen-lockfile`, which will always install exactly the dependencies as specified in the yarn.lock file and not try to do anything else, never updating the yarn.lock file.