### PR TITLE
feat: allow for bot to edit existing asset size comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ jobs:
     - uses: simplabs/ember-asset-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        update-comments: true
 ```
+
+`update-comments` is an optional input. When set to true the bot will search for a comment it has already made on an issue and update it, instead of creating a new one each run.
 
 Note: as this action requires access to the "base" commit of a PR branch we need to fetch the whole repo by adding `fetch-depth: 0` to the `actions/checkout` configuration.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ jobs:
     - uses: simplabs/ember-asset-size-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        update-comments: true
 ```
 
-`update-comments` is an optional input. When set to true the bot will search for a comment it has already made on an issue and update it, instead of creating a new one each run.
+By default `ember-asset-size-action` will update the existing comment when the PR has been updated in any way.
+
+If you want to disable this behaviour and have the action create a new comment every time, you can pass the input `update-comments` with a value `false`.
+
+```yaml
+- uses: simplabs/ember-asset-size-action@v1
+  with:
+    repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    update-comments: "no" # apparently booleans don't work as expected
+```
 
 Note: as this action requires access to the "base" commit of a PR branch we need to fetch the whole repo by adding `fetch-depth: 0` to the `actions/checkout` configuration.
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,8 @@ branding:
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
+  update-comments:
+    description: 'Optional: Set to true to update existing asset size comment instead of creating a new one each time'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,9 @@ inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
   update-comments:
-    description: 'Optional: Set to true to update existing asset size comment instead of creating a new one each time'
+    description: 'Update existing asset size comment instead of creating a new one each time'
+    required: false
+    default: 'yes'
 runs:
   using: 'node12'
   main: 'index.js'

--- a/main.js
+++ b/main.js
@@ -32,7 +32,7 @@ async function run() {
     const updateExistingComment = getInput('update-comments', { required: false });
     let existingComment = false;
 
-    if (updateExistingComment) {
+    if (updateExistingComment === 'yes') {
       const { data: comments } = await octokit.issues.listComments({
         owner: context.repo.owner,
         repo: context.repo.repo,

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ async function run() {
 
     const fileDiffs = diffSizes(normaliseFingerprint(masterAssets), normaliseFingerprint(prAssets));
 
-    const uniqueCommentIdentifier = '_Created by ember-asset-size-action_';
+    const uniqueCommentIdentifier = '_Created by [ember-asset-size-action](https://github.com/simplabs/ember-asset-size-action/)_';
     const body = `${buildOutputText(fileDiffs)}\n\n${uniqueCommentIdentifier}`;
 
     const updateExistingComment = getInput('update-comments', { required: false });


### PR DESCRIPTION
closes https://github.com/simplabs/ember-asset-size-action/issues/9

Adds an optional config option `update-comments` to have the bot update existing comments rather than create new ones. Code adapted from a fork that implements this https://github.com/backspace/ember-asset-size-action/commit/040f42b218b77ad3bca9bb2cba479f73d742006f

From another repo I have that is using this PR
![Screenshot from 2021-01-28 09-27-39](https://user-images.githubusercontent.com/1049837/106070217-c1ffa780-614f-11eb-984f-8d219a7932fb.png)
^ original comment
v edited comment when a new commit is pushed
![Screenshot from 2021-01-28 10-00-51](https://user-images.githubusercontent.com/1049837/106070214-c0ce7a80-614f-11eb-9eb7-69c5eba0565c.png)
