### PR TITLE
Update README for on demand runs and NPM tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,58 @@ jobs:
 Note: as this action requires access to the "base" commit of a PR branch we need to fetch the whole repo by adding `fetch-depth: 0` to the `actions/checkout` configuration.
 
 If you would like to follow discussion on this problem you can find the issue on github here: https://github.com/actions/checkout/issues/93
+
+### Running Github Action on demand with labels
+
+If running this Github Action on every push is not suitable, you can configure it to run only when a certain label is attached to pull request, for example when you add the `ember-asset-size` label:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, labeled] # necessary to watch for when the label is added
+
+jobs:
+  build:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ember-asset-size') }}
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2-beta
+      with:
+        fetch-depth: 0
+    - uses: simplabs/ember-asset-size-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+```
+
+This technique isn't anything special to ember-asset-size-tracking, it is a feature of GitHub actions, and you can read more about it in [their official documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif)
+
+### Configuring your private npm package registry token
+
+If your app depends on private npm packages, you will need to make sure that you have the correct NPM_TOKEN available to your repo so that the `npm install` or `yarn install` step will succeed.
+
+More details on how to [configure your npm registry token](https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file).
+
+The following example allows you to **not** commit the `.npmrc` to your repo, and instead creates it just before it is needed.
+
+```yaml
+name: Ember Asset Sizes
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2-beta
+      with:
+        fetch-depth: 0
+    - run: echo //registry.npmjs.org/:_authToken=$\{NPM_TOKEN\} >> .npmrc
+    - uses: simplabs/ember-asset-size-action@v1
+      env:
+        NPM_TOKEN: "${{ secrets.YOUR_REPO_NPM_TOKEN }}"
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+```


### PR DESCRIPTION
Update README with details how to run ember-asset-size action conditionally and with private/authenticated NPM registries.

Closes #22 