### PR TITLE
use npm@7 to install dependencies if needed

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -64,12 +64,31 @@ export async function getPullRequest(context, octokit) {
   return pullRequest;
 }
 
-export async function getAssetSizes() {
+export async function installDependencies() {
   if (fs.existsSync('yarn.lock')) {
-    await exec('yarn --frozen-lockfile');
-  } else {
-    await exec('npm ci');
+    return exec('yarn --frozen-lockfile');
   }
+
+  if (fs.existsSync('package-lock.json')) {
+    const packageLock = JSON.parse(fs.readFileSync('package-lock.json'));
+    const npmVersion = await exec('npm -v');
+
+    if (
+      packageLock.lockfileVersion === 2
+      && !npmVersion.startsWith('7')
+    ) {
+      return exec('npx npm@7 ci');
+    }
+
+    return exec('npm ci');
+  }
+
+  console.warn('No package-lock.json or yarn.lock detected! We strongly recommend committing one');
+  return exec('npm install');
+}
+
+export async function getAssetSizes() {
+  await installDependencies();
 
   await exec('npx ember build -prod');
 


### PR DESCRIPTION
I recently tried `ember-asset-size-action` with a repo that needed npm@7 and got a strange error: https://github.com/mansona/ember-action-test/pull/1/checks?check_run_id=2792656071#step:3:5

This PR detects the lockfile version and uses npm@7 if necessary 👍 