### PR TITLE
adds 'show-totals' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 ```
 
+### Displaying total asset sizes
+
+If you'd like the PR comment to display total asset sizes for the PR's build, not just the diff compared to the base branch, you can use the `show-totals` option:
+
+```yaml
+- uses: simplabs/ember-asset-size-action@v1
+  with:
+    repo-token: "${{ secrets.GITHUB_TOKEN }}"
+    show-totals: "yes"
+```
+
 ## License
 
 Ember Simple Auth is developed by and &copy; [simplabs GmbH](http://simplabs.com) and contributors. It is released under the [MIT License](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ branding:
 inputs:
   repo-token:
     description: 'The GITHUB_TOKEN secret'
+  show-totals:
+    description: 'Display a table of bundle size total sizes'
+    required: false
+    default: 'no'
   update-comments:
     description: 'Update existing asset size comment instead of creating a new one each time'
     required: false

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -112,6 +112,27 @@ export async function getAssetSizes() {
   return prAssets;
 }
 
+export function sumAssetSizes(assetSizeReport) {
+  return Object.entries(assetSizeReport).reduce(
+    (acc, [filename, fileMeta]) => {
+      let fileType;
+      if (filename.endsWith('.js')) {
+        fileType = 'js';
+      } else if (filename.endsWith('.css')) {
+        fileType = 'css';
+      } else {
+        return acc;
+      }
+
+      acc[fileType].raw += fileMeta.raw;
+      acc[fileType].gzip += fileMeta.gzip;
+
+      return acc;
+    },
+    { js: { raw: 0, gzip: 0 }, css: { raw: 0, gzip: 0 } },
+  );
+}
+
 function reportTable(data) {
   let table = `File | raw | gzip
 --- | --- | ---

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -144,7 +144,7 @@ function reportTable(data) {
   return table;
 }
 
-export function buildOutputText(output) {
+export function buildOutputText(output, totals) {
   const files = Object.keys(output).map((key) => ({
     file: key,
     raw: output[key].raw,
@@ -177,6 +177,15 @@ export function buildOutputText(output) {
 
   if (same.length) {
     outputText += `Files that stayed the same size 🤷‍:\n\n${reportTable(same)}\n\n`;
+  }
+
+  if (totals) {
+    const totalsRows = [
+      { file: 'js', ...totals.js },
+      { file: 'css', ...totals.css },
+    ];
+
+    outputText += `Total Sizes 📊:\n\n${reportTable(totalsRows)}`;
   }
 
   return outputText.trim();

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ import {
   buildOutputText,
   getPullRequest,
   getAssetSizes,
+  sumAssetSizes,
 } from './lib/helpers';
 
 let octokit;
@@ -18,7 +19,9 @@ async function run() {
     octokit = getOctokit(myToken);
     const pullRequest = await getPullRequest(context, octokit);
 
+    const showTotals = getInput('show-totals', { required: false }) === 'yes';
     const prAssets = await getAssetSizes();
+    const prTotals = showTotals ? sumAssetSizes(prAssets) : undefined;
 
     await exec(`git checkout ${pullRequest.base.sha}`);
 
@@ -27,7 +30,7 @@ async function run() {
     const fileDiffs = diffSizes(normaliseFingerprint(masterAssets), normaliseFingerprint(prAssets));
 
     const uniqueCommentIdentifier = '_Created by [ember-asset-size-action](https://github.com/simplabs/ember-asset-size-action/)_';
-    const body = `${buildOutputText(fileDiffs)}\n\n${uniqueCommentIdentifier}`;
+    const body = `${buildOutputText(fileDiffs, prTotals)}\n\n${uniqueCommentIdentifier}`;
 
     const updateExistingComment = getInput('update-comments', { required: false });
     let existingComment = false;

--- a/test/buildOutputText.js
+++ b/test/buildOutputText.js
@@ -36,4 +36,51 @@ ember-website-fastboot.js| 0 B| 0 B
 ember-website.css| 0 B| 0 B
 vendor.css| 0 B| 0 B`);
   });
+
+  it('should include total asset sizes when provided', function () {
+    const diff = {
+      'auto-import-fastboot.js': { raw: 221142, gzip: 76707 },
+      'ember-website.js': { raw: -2995, gzip: -1013 },
+      'ember-website-fastboot.js': { raw: 0, gzip: 0 },
+      'vendor.js': { raw: -388401, gzip: -129560 },
+      'ember-website.css': { raw: 0, gzip: 0 },
+      'vendor.css': { raw: 0, gzip: 0 },
+    };
+    const totals = {
+      js: { raw: 3329042, gzip: 945089 },
+      css: { raw: 98184, gzip: 28143 },
+    };
+
+    const text = buildOutputText(diff, totals);
+
+    expect(text).to.equal(`Files that got Bigger 🚨:
+
+File | raw | gzip
+--- | --- | ---
+auto-import-fastboot.js|+221 kB|+76.7 kB
+
+Files that got Smaller 🎉:
+
+File | raw | gzip
+--- | --- | ---
+ember-website.js|-3 kB|-1.01 kB
+vendor.js|-388 kB|-130 kB
+
+
+Files that stayed the same size 🤷‍:
+
+File | raw | gzip
+--- | --- | ---
+ember-website-fastboot.js| 0 B| 0 B
+ember-website.css| 0 B| 0 B
+vendor.css| 0 B| 0 B
+
+
+Total Sizes 📊:
+
+File | raw | gzip
+--- | --- | ---
+js|+3.33 MB|+945 kB
+css|+98.2 kB|+28.1 kB`);
+  });
 });

--- a/test/sumAssetSizes.js
+++ b/test/sumAssetSizes.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { sumAssetSizes } from '../lib/helpers.js';
+
+describe('sumAssetSizes', function () {
+  it('sums the total sizes for each file type', function() {
+    const assetSizeReport = {
+      'ember-website.js': { raw: 1000, gzip: 10, brotli: null },
+      'vendor.js': { raw: 1000, gzip: 10, brotli: null },
+      'ember-website.css': { raw: 1000, gzip: 10, brotli: null },
+      'vendor.css': { raw: 1000, gzip: 10, brotli: null },
+    };
+
+    const summedAssetSizes = sumAssetSizes(assetSizeReport);
+
+    expect(summedAssetSizes).to.deep.equal({
+      css: {
+        raw: 2000,
+        gzip: 20,
+      },
+      js: {
+        raw: 2000,
+        gzip: 20,
+      },
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `show-totals` option, defaulting to `no`.

When set to `yes`, it will display a table of summed file sizes, one row for JS, one for CSS.

This addresses my own feature request in https://github.com/simplabs/ember-asset-size-action/issues/24.

Here's a screenshot of it working from my fork:
![totals](https://user-images.githubusercontent.com/1470250/121613157-3dc71480-ca9f-11eb-8ce6-6a9f711fa74d.png)

CC @mansona 