### PR TITLE
reset back to using esm

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -7,6 +7,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+    - run: npm i -g npm@7
+
     - name: "npm ci"
       run: npm ci
 

--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -5,7 +5,7 @@ jobs:
   check_pr:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - uses: actions/setup-node@v2
       with:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "eslint": "^7.28.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.23.4",
-    "mocha": "^9.0.0"
+    "mocha": "^8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "private": true,
   "description": "Show asset size changes on ",
   "main": "index.js",
-  "type": "module",
   "scripts": {
-    "test": "cross-env NODE_ENV=TEST GITHUB_REPOSITORY=simplabs/ember-asset-size-action mocha"
+    "test": "cross-env NODE_ENV=TEST GITHUB_REPOSITORY=simplabs/ember-asset-size-action mocha -r esm"
   },
   "repository": {
     "type": "git",

--- a/test/buildOutputText.js
+++ b/test/buildOutputText.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { buildOutputText } from '../lib/helpers.js';
+import { buildOutputText } from '../lib/helpers';
 
 describe('Build output Text', function () {
   it('should show the correct table output for a file diff', function () {

--- a/test/diffSizes.js
+++ b/test/diffSizes.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { diffSizes } from '../lib/helpers.js';
+import { diffSizes } from '../lib/helpers';
 
 describe('Diff Sizes', function () {
   it('should show correct diffs for each file', function () {

--- a/test/normaliseFingerprint.js
+++ b/test/normaliseFingerprint.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { normaliseFingerprint } from '../lib/helpers.js';
+import { normaliseFingerprint } from '../lib/helpers';
 
 describe('Normalise Fingerprint', function () {
   it('should remove fingerprints from file names', function () {


### PR DESCRIPTION
so there was [an announcement a while ago that all GitHub actions would use Node 14](https://github.com/actions/virtual-environments/issues/1953) but it turns out that was a bit of a misleading announcement. That only applies for the environment that the actions are run in but not the actions themselves 🤦 

There is an [open issue requesting that actions have the ability to run in Node 14](https://github.com/actions/runner/issues/772) that seems to be blocked for some reason. 

Long story short: I was a bit preemptive removing the use of [esm](https://www.npmjs.com/package/esm) from ember-asset-size-action since we can't make use of native esm modules just yet 😞 

Edit: turns out that mocha 9 doesn't work in this setup because it is enabling partial esm support even though you need the flag for that to work correctly 🙃 