### PR TITLE
fix npmVersion std out

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -70,7 +70,12 @@ export async function installDependencies() {
 
   if (fs.existsSync('package-lock.json')) {
     const packageLock = JSON.parse(fs.readFileSync('package-lock.json'));
-    const npmVersion = await exec('npm -v');
+    let npmVersion = '';
+    await exec('npm -v', {
+      stdout: (data) => {
+        npmVersion += data.toString();
+      },
+    });
 
     if (
       packageLock.lockfileVersion === 2


### PR DESCRIPTION
So.. funny thing 🙈 It turns out that I was reading the documentation for [execa](https://npmjs.com/execa) when I was actually using `exec` from `'@actions/exec'` 😫 

I won't tell you how much time this wasted for me 🙃 hint: i said how much on twitter 😂 